### PR TITLE
Fix bank offset calculation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -676,7 +676,7 @@ uchar XbitFlasher::CalculateBlockIndexForOffset(int offset)
 int XbitFlasher::GetStartblockForBank(int layout, int bank)
 {
 	int offset = 0;
-	for(int i=1; i <= bank; i++){
+	for(int i=1; i < bank; i++){
 		offset += GetSizeForBank(layout, i);
 	}
 	return CalculateBlockIndexForOffset(offset);

--- a/main.cpp
+++ b/main.cpp
@@ -504,7 +504,7 @@ bool XbitFlasher::EraseBank(int bank)
 	int res = 0;
 	int bank_size = GetSizeForBank(this->memory_layout_id, bank);
 	int current_block = GetStartblockForBank(this->memory_layout_id, bank);
-	int block_count = CalculateBlocksizeForOffset(bank_size);
+	int block_count = CalculateBlockIndexForOffset(bank_size);
 
 	if(IsDeviceWriteprotected()){
 		printf("Modchip is write-protected?!?! Try resetting it by replugging USB cable..\n");
@@ -539,7 +539,7 @@ bool XbitFlasher::FlashBank(int bank, uchar *input_data, int data_length)
 	int res = 0;
 	int bank_size = GetSizeForBank(this->memory_layout_id, bank);
 	int start_block = GetStartblockForBank(this->memory_layout_id, bank);
-	int block_count = CalculateBlocksizeForOffset(bank_size);
+	int block_count = CalculateBlockIndexForOffset(bank_size);
 
 	if(bank_size != data_length){
 		printf("BIOS size %i does not match bank size %i\n", data_length, bank_size);
@@ -593,7 +593,7 @@ bool XbitFlasher::ReadBank(int bank, uchar *output_data, int *num_bytes_read)
 	int res;
 	int bank_size = GetSizeForBank(this->memory_layout_id, bank);
 	int start_block = GetStartblockForBank(this->memory_layout_id, bank);
-	int block_count = CalculateBlocksizeForOffset(bank_size);
+	int block_count = CalculateBlockIndexForOffset(bank_size);
 
 	if(IsDeviceWriteprotected()){
 		printf("Modchip is write-protected?!?! Try resetting it by replugging USB cable..\n");
@@ -661,7 +661,7 @@ bool XbitFlasher::VerifyBank(int bank, uchar *input_data, int data_length)
 	return true;
 }
 
-uchar XbitFlasher::CalculateBlocksizeForOffset(int offset)
+uchar XbitFlasher::CalculateBlockIndexForOffset(int offset)
 {
 	if(offset == 0){
 		return 0;
@@ -679,7 +679,7 @@ int XbitFlasher::GetStartblockForBank(int layout, int bank)
 	for(int i=1; i <= bank; i++){
 		offset += GetSizeForBank(layout, i);
 	}
-	return CalculateBlocksizeForOffset(offset);
+	return CalculateBlockIndexForOffset(offset);
 }
 
 int XbitFlasher::GetSizeForBank(int layout, int bank)

--- a/xbit.h
+++ b/xbit.h
@@ -155,7 +155,7 @@ private:
 	bool WriteFlash(uchar flash, uchar sector, uint16 offset, uchar *buffer, uint16 nBytes);
 	bool EraseBlock(int flash, int sector);
 
-	uchar CalculateBlocksizeForOffset(int offset);
+	uchar CalculateBlockIndexForOffset(int offset);
 	int GetStartblockForBank(int layout, int bank);
 	int GetSizeForBank(int layout, int bank);
 };


### PR DESCRIPTION
So, this should fix #2. I guess I was a bit too tired yesterday and focused on way to convoluted theories. There's an off-by-one when calculating the base block index where a bank starts. It includes the size of the bank itself in the calculation, so all the data would be written right past the end of the bank in question. Fix is simply `<` instead of `<=` :-)  
I dared to rename `CalculateBlocksizeForOffset` in the process, as it's not really a size but an offset/index.

(Also this time I didn't forget to create a new branch -- last time my NOTES file slipped in, don't know if you actually want that in your tree...)